### PR TITLE
Parallelize the statistics

### DIFF
--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -17,9 +17,10 @@ import qualified Pipes.Prelude as P
 import System.Random.MWC.Monad (Rand, runWithCreate)
 
 import TauSigma.Statistics.Types
-import TauSigma.Statistics.Allan (adevs)
+import TauSigma.Statistics.Allan (adevs, mdevs)
 import TauSigma.Statistics.Hadamard (hdevs)
-import TauSigma.Statistics.Theo1 (theo1devs, theoBRdevs)
+import TauSigma.Statistics.Total (totdevs)
+import TauSigma.Statistics.Theo1 (theo1devs, theoBRdevs, theoHdevs)
 
 import TauSigma.Util.Pipes.Noise
   ( TimeData
@@ -41,9 +42,12 @@ main :: IO ()
 main = defaultMain tests
   where tests = [ noiseTests
                 , adevTests
+                , mdevTests
                 , hdevTests
+                , totdevTests
                 , theo1Tests
                 , theoBRTests
+                , theoHTests
                 ]
 
 
@@ -84,9 +88,21 @@ adevTests = bgroup "adev" (runStatistic statistic wfm sizes)
         wfm = whiteFrequency 1.0 >-> toPhase
         sizes = [50, 500, 5000]
 
+mdevTests :: Benchmark
+mdevTests = bgroup "mdev" (runStatistic statistic wfm sizes)
+  where statistic = mdevs 1
+        wfm = whiteFrequency 1.0 >-> toPhase
+        sizes = [50, 500, 5000]
+
 hdevTests :: Benchmark
 hdevTests = bgroup "hdev" (runStatistic statistic wfm sizes)
   where statistic = hdevs 1
+        wfm = whiteFrequency 1.0 >-> toPhase
+        sizes = [50, 500, 5000]
+
+totdevTests :: Benchmark
+totdevTests = bgroup "totdev" (runStatistic statistic wfm sizes)
+  where statistic = totdevs 1
         wfm = whiteFrequency 1.0 >-> toPhase
         sizes = [50, 500, 5000]
 
@@ -101,6 +117,13 @@ theoBRTests = bgroup "theoBR" (runStatistic statistic wfm sizes)
   where statistic = theoBRdevs 1
         wfm = whiteFrequency 1.0 >-> toPhase
         sizes = [200, 400, 600]
+
+theoHTests :: Benchmark
+theoHTests = bgroup "theoH" (runStatistic statistic wfm sizes) 
+  where statistic = theoHdevs 1
+        wfm = whiteFrequency 1.0 >-> toPhase
+        sizes = [200, 400, 600]
+
 
 runStatistic
   :: Statistic

--- a/tau-sigma.cabal
+++ b/tau-sigma.cabal
@@ -1,5 +1,5 @@
 name:                tau-sigma
-version:             0.4.3
+version:             0.4.4
 synopsis:            A command-line utility for frequency stability analysis.
 license:             BSD3
 license-file:        LICENSE
@@ -46,6 +46,7 @@ library
                      , mwc-random-monad
                      , monad-primitive
                      , optparse-applicative 
+                     , parallel
                      , pipes 
                      , pipes-bytestring
                      , pipes-csv
@@ -59,7 +60,7 @@ library
 executable tau-sigma
   default-language:    Haskell2010
   hs-source-dirs:      app
-  Ghc-Options:         -Wall -O
+  Ghc-Options:         -Wall -O -threaded -rtsopts -with-rtsopts=-N
   main-is:             Main.hs
   build-depends:       base >=4.7 && <5
                      , mtl

--- a/tau-sigma.cabal
+++ b/tau-sigma.cabal
@@ -90,14 +90,16 @@ Benchmark bench
   Type:                exitcode-stdio-1.0
   Default-Language:    Haskell2010
   Hs-Source-Dirs:      bench
-  Ghc-Options:         -Wall -O -rtsopts -fprof-auto
+  Ghc-Options:         -Wall -O -threaded -rtsopts -with-rtsopts=-N -fprof-auto
   Main-Is:             Bench.hs
   Build-Depends:       base >=4.7 && <5
                      , criterion
                      , mwc-random
                      , mwc-random-monad
+                     , parallel
                      , pipes
                      , primitive
                      , tagged
                      , tau-sigma 
                      , vector
+


### PR DESCRIPTION
The statistical commands now compute the results' tau/sigma pairs in parallel.  This is wasteful when running the simpler stats (`adev`, `hdev`) at smaller sizes, but pays off big with the more complex stats (`mdev`, `tdev`, `totdev`, `theobr` and `theoh`) and larger data sets.
