### PR TITLE
KBN summation

### DIFF
--- a/src/TauSigma/Statistics/Allan.hs
+++ b/src/TauSigma/Statistics/Allan.hs
@@ -32,7 +32,11 @@ import TauSigma.Statistics.Util
 
 
 -- | Overlapped estimator of Allan variance at one sampling interval.
-avar :: (Fractional a, Vector v a) => Tau0 a -> Int -> v (Time a) -> Sigma a
+avar :: (Vector v Double) =>
+        Tau0 Double
+     -> Int
+     -> v (Time Double)
+     -> Sigma Double
 {-# INLINABLE avar #-}
 avar tau0 m xs = sumsq 0 (V.length xs - 2*m) term / divisor
   where divisor = 2 * m'^2 * tau0^2 * (len - 2*m')
@@ -41,25 +45,29 @@ avar tau0 m xs = sumsq 0 (V.length xs - 2*m) term / divisor
         term i  = xs!(i+2*m) - 2*(xs!(i+m)) + xs!i
 
 -- | Overlapped estimator of Allan deviation at one sampling interval.
-adev :: (Floating a, Vector v a) => Tau0 a -> Int -> v (Time a) -> Sigma a
+adev :: (Vector v Double) =>
+        Tau0 Double -> Int -> v (Time Double) -> Sigma Double
 {-# INLINABLE adev #-}
 adev tau0 m xs = sqrt (avar tau0 m xs)
 
 -- | Overlapped estimator of Allan variance at all sampling intervals.
-avars :: (RealFrac a, Vector v a) => Tau0 a -> v (Time a) -> [TauSigma a]
+avars :: (Vector v Double) =>
+         Tau0 Double -> v (Time Double) -> [TauSigma Double]
 {-# INLINABLE avars #-}
 avars tau0 xs = map go taus
   where taus = [1 .. (V.length xs - 1) `div` 2]
         go m = (fromIntegral m * tau0, avar tau0 m xs)
 
 -- | Overlapped estimator of Allan deviation at all sampling intervals.
-adevs :: (RealFloat a, Vector v a) => Tau0 a -> v (Time a) -> [TauSigma a]
+adevs :: (Vector v Double) =>
+         Tau0 Double -> v (Time Double) -> [TauSigma Double]
 {-# INLINABLE adevs #-}
 adevs tau0 xs = over (traverse . _2) sqrt (avars tau0 xs)
 
 
 -- | Estimator of Modified Allan variance at one sampling interval.
-mvar :: (Fractional a, Vector v a) => Tau0 a -> Int -> v (Time a) -> Sigma a
+mvar :: (Vector v Double) =>
+        Tau0 Double -> Int -> v (Time Double) -> Sigma Double
 {-# INLINABLE mvar #-}
 {- FIXME: slow... -}
 mvar tau0 m xs = outer / divisor
@@ -71,39 +79,46 @@ mvar tau0 m xs = outer / divisor
       where inner j = summation "mvar" j (j + m) term
               where term i = xs!(i+2*m) - 2*(xs!(i+m)) + xs!i
 
-mdev :: (Floating a, Vector v a) => Tau0 a -> Int -> v (Time a) -> Sigma a
+mdev :: (Vector v Double) =>
+        Tau0 Double -> Int -> v (Time Double) -> Sigma Double
 {-# INLINABLE mdev #-}
 mdev tau0 m xs = sqrt (mvar tau0 m xs)
 
-mvars :: (RealFrac a, Vector v a) => Tau0 a -> v (Time a) -> [TauSigma a]
+mvars :: (Vector v Double) =>
+         Tau0 Double -> v (Time Double) -> [TauSigma Double]
 {-# INLINABLE mvars #-}
 mvars tau0 xs = map go taus
   where taus = [1 .. (V.length xs - 1) `div` 3]
         go m = (fromIntegral m * tau0, mvar tau0 m xs)
                     
-mdevs :: (RealFloat a, Vector v a) => Tau0 a -> v (Time a) -> [TauSigma a]
+mdevs :: (Vector v Double) =>
+         Tau0 Double -> v (Time Double) -> [TauSigma Double]
 {-# INLINABLE mdevs #-}
 mdevs tau0 xs = over (traverse . _2) sqrt (mvars tau0 xs)
 
 
-tvar :: (Fractional a, Vector v a) => Tau0 a -> Int -> v (Time a) -> Sigma a
+tvar :: (Vector v Double) =>
+        Tau0 Double -> Int -> v (Time Double) -> Sigma Double
 {-# INLINABLE tvar #-}
 tvar tau0 m xs = mvar2tvar (tau0 * fromIntegral m) (mvar tau0 m xs)
 
-tdev :: (Floating a, Vector v a) => Tau0 a -> Int -> v (Time a) -> Sigma a
+tdev :: (Vector v Double) =>
+        Tau0 Double -> Int -> v (Time Double) -> Sigma Double
 {-# INLINABLE tdev #-}
 tdev tau0 m xs = sqrt (tvar tau0 m xs)
 
-tvars :: (RealFrac a, Vector v a) => Tau0 a -> v (Time a) -> [TauSigma a]
+tvars :: (Vector v Double) =>
+         Tau0 Double -> v (Time Double) -> [TauSigma Double]
 {-# INLINABLE tvars #-}
 tvars tau0 xs = map go (mvars tau0 xs)
   where go (tau, sigma) = (tau, mvar2tvar tau sigma)
                     
-tdevs :: (RealFloat a, Vector v a) => Tau0 a -> v (Time a) -> [TauSigma a]
+tdevs :: (Vector v Double) =>
+         Tau0 Double -> v (Time Double) -> [TauSigma Double]
 {-# INLINABLE tdevs #-}
 tdevs tau0 xs = over (traverse . _2) sqrt (tvars tau0 xs)
 
-mvar2tvar :: Fractional a => Tau a -> Sigma a -> Sigma a
+mvar2tvar :: Tau Double -> Sigma Double -> Sigma Double
 {-# INLINE mvar2tvar #-}
 mvar2tvar tau a = (tau^2 / 3) * a
 

--- a/src/TauSigma/Statistics/Hadamard.hs
+++ b/src/TauSigma/Statistics/Hadamard.hs
@@ -22,7 +22,8 @@ import TauSigma.Statistics.Util
 
 
 -- | Overlapped estimator of Hadamard variance at one sampling interval.
-hvar :: (Fractional a, Vector v a) => Tau0 a -> Int -> v (Time a) -> Sigma a
+hvar :: (Vector v Double) =>
+        Tau0 Double -> Int -> v (Time Double) -> Sigma Double
 {-# INLINABLE hvar #-}
 hvar tau0 m xs = sumsq 0 (V.length xs - 3*m) term / divisor
   where divisor = 6 * m'^2 * tau0^2 * (len - 3*m')
@@ -31,7 +32,8 @@ hvar tau0 m xs = sumsq 0 (V.length xs - 3*m) term / divisor
         term i = xs!(i+3*m) - 3*xs!(i+2*m) + 3*xs!(i+m) - xs!i
 
 -- | Overlapped estimator of Hadamard deviation at one sampling interval.
-hdev :: (Floating a, Vector v a) => Tau0 a -> Int -> v (Time a) -> Sigma a
+hdev :: (Vector v Double) =>
+        Tau0 Double -> Int -> v (Time Double) -> Sigma Double
 {-# INLINABLE hdev #-}
 hdev tau0 m xs = sqrt (hvar tau0 m xs)
 
@@ -39,7 +41,8 @@ hdev tau0 m xs = sqrt (hvar tau0 m xs)
 -- Note that this returns a lazy list whose thunks hold on to the
 -- input vector.  You're going to want to force the ones you want right
 -- away and discard the rest!
-hvars :: (RealFrac a, Vector v a) => Tau0 a -> v (Time a) -> [TauSigma a]
+hvars :: (Vector v Double) =>
+         Tau0 Double -> v (Time Double) -> [TauSigma Double]
 {-# INLINABLE hvars #-}
 hvars tau0 xs = map go taus
   where taus = [1 .. (V.length xs - 1) `div` 3]
@@ -49,6 +52,7 @@ hvars tau0 xs = map go taus
 -- Note that this returns a lazy list whose thunks hold on to the
 -- input vector.  You're going to want to force the ones you want right
 -- away and discard the rest!
-hdevs :: (RealFloat a, Vector v a) => Tau0 a -> v (Time a) -> [TauSigma a]
+hdevs :: (Vector v Double) =>
+         Tau0 Double -> v (Time Double) -> [TauSigma Double]
 {-# INLINABLE hdevs #-}
 hdevs tau0 xs = over (traverse . _2) sqrt (hvars tau0 xs)

--- a/src/TauSigma/Statistics/Theo1.hs
+++ b/src/TauSigma/Statistics/Theo1.hs
@@ -38,7 +38,7 @@ theo1Tau tau0 m
   | even m && 10 <= m = Just (unsafeTheo1Tau tau0 m)
   | otherwise         = Nothing
 
-unsafeTheo1Tau :: Fractional a => Tau0 Double -> Int -> Tau Double
+unsafeTheo1Tau :: Tau0 Double -> Int -> Tau Double
 unsafeTheo1Tau tau0 m = 0.75 * fromIntegral m * tau0
 
 

--- a/src/TauSigma/Statistics/Theo1.hs
+++ b/src/TauSigma/Statistics/Theo1.hs
@@ -33,12 +33,12 @@ import TauSigma.Statistics.Types
 import TauSigma.Statistics.Util
 
 
-theo1Tau :: Fractional a => Tau0 a -> Int -> Maybe (Tau a)
+theo1Tau :: Tau0 Double -> Int -> Maybe (Tau Double)
 theo1Tau tau0 m
   | even m && 10 <= m = Just (unsafeTheo1Tau tau0 m)
   | otherwise         = Nothing
 
-unsafeTheo1Tau :: Fractional a => Tau0 a -> Int -> Tau a
+unsafeTheo1Tau :: Fractional a => Tau0 Double -> Int -> Tau Double
 unsafeTheo1Tau tau0 m = 0.75 * fromIntegral m * tau0
 
 
@@ -52,8 +52,8 @@ theo1Steps size = filter (flip isTheo1Step size) [1 .. 3 * (size `div` 4)]
 
 
 theo1var
-  :: (Fractional a, Vector v a) =>
-     Tau0 a -> Int -> v (Time a) -> Maybe (TauSigma a)
+  :: (Vector v Double) =>
+     Tau0 Double -> Int -> v (Time Double) -> Maybe (TauSigma Double)
 {-# INLINABLE theo1var #-}
 theo1var tau0 m xs
   | m `isTheo1Step` V.length xs =
@@ -61,25 +61,27 @@ theo1var tau0 m xs
   | otherwise = Nothing
 
 theo1dev
-  :: (Floating a, Vector v a) =>
-     Tau0 a -> Int -> v (Time a) -> Maybe (TauSigma a)
+  :: (Vector v Double) =>
+     Tau0 Double -> Int -> v (Time Double) -> Maybe (TauSigma Double)
 {-# INLINABLE theo1dev #-}
 theo1dev tau0 m xs = over (_Just . _2) sqrt (theo1var tau0 m xs)
 
-theo1vars :: (Fractional a, Vector v a) => Tau0 a -> v (Time a) -> [TauSigma a]
+theo1vars :: (Vector v Double) =>
+             Tau0 Double -> v (Time Double) -> [TauSigma Double]
 {-# INLINABLE theo1vars #-}
 theo1vars tau0 xs = map go (theo1Steps size)
   where size = V.length xs
         go m = (unsafeTheo1Tau tau0 m, unsafeTheo1var tau0 m xs)
 
-theo1devs :: (Floating a, Vector v a) => Tau0 a -> v (Time a) -> [TauSigma a]
+theo1devs :: (Vector v Double) =>
+             Tau0 Double -> v (Time Double) -> [TauSigma Double]
 {-# INLINABLE theo1devs #-}
 theo1devs tau0 xs = over (traverse . _2) sqrt (theo1vars tau0 xs)
 
 
 unsafeTheo1var
-  :: (Fractional a, Vector v a) =>
-     Tau0 a -> Int -> v (Time a) -> Sigma a
+  :: (Vector v Double) =>
+     Tau0 Double -> Int -> v (Time Double) -> Sigma Double
 {-# INLINABLE unsafeTheo1var #-}
 unsafeTheo1var tau0 m xs = outer / (0.75 * divisor)
   where divisor = (len - m') * (m' * tau0)^2
@@ -93,17 +95,16 @@ unsafeTheo1var tau0 m xs = outer / (0.75 * divisor)
                                      + (xs!(i+m) -xs!(i + d + halfM))
 
 unsafeTheo1dev
-  :: (Floating a, Vector v a) =>
-     Tau0 a -> Int -> v (Time a) -> Sigma a
+  :: (Vector v Double) =>
+     Tau0 Double -> Int -> v (Time Double) -> Sigma Double
 {-# INLINABLE unsafeTheo1dev #-}
 unsafeTheo1dev tau0 m xs = sqrt (unsafeTheo1var tau0 m xs)
 
 
 -- | Bias-reduced Theo1 variance.  
 theoBRvars
-  :: forall v a.
-     (RealFrac a, Vector v a) =>
-     Tau0 a -> v (Time a) -> [TauSigma a]
+  :: (Vector v Double) =>
+     Tau0 Double -> v (Time Double) -> [TauSigma Double]
 {-# INLINABLE theoBRvars #-}
 theoBRvars tau0 xs
   | n > 0 = map go (theo1Steps (V.length xs))
@@ -112,7 +113,7 @@ theoBRvars tau0 xs
     n :: Int
     n = floor (((0.1 * fromIntegral (V.length xs)) / 3) - 3)
 
-    go :: Int -> TauSigma a
+    go :: Int -> TauSigma Double
     go m = (tau, sigma)
       where
         tau = 0.75 * fromIntegral m * tau0
@@ -125,14 +126,15 @@ theoBRvars tau0 xs
 
 
 theoBRdevs
-  :: (Floating a, RealFrac a, Vector v a) =>
-     Tau0 a -> v (Time a) -> [TauSigma a]
+  :: (Vector v Double) =>
+     Tau0 Double -> v (Time Double) -> [TauSigma Double]
 {-# INLINABLE theoBRdevs #-}
 theoBRdevs tau0 xs = over (traverse . _2) sqrt (theoBRvars tau0 xs)
 
 
                            
-theoHvars :: (RealFrac a, Vector v a) => Tau0 a -> v (Time a) -> [TauSigma a]
+theoHvars
+    :: (Vector v Double) => Tau0 Double -> v (Time Double) -> [TauSigma Double]
 {-# INLINABLE theoHvars #-}
 theoHvars tau0 xs = mergeOn fst allans theoBRs
   where k = fromIntegral (V.length xs `div` 10) * tau0
@@ -149,8 +151,8 @@ mergeOn f xs'@(x:xs) ys'@(y:ys)
   | otherwise = y : mergeOn f xs' ys
 
 theoHdevs
-  :: (RealFrac a, Floating a, Vector v a) =>
-     Tau0 a -> v (Time a) -> [TauSigma a]
+  :: (Vector v Double) =>
+     Tau0 Double -> v (Time Double) -> [TauSigma Double]
 {-# INLINABLE theoHdevs #-}
 theoHdevs tau0 xs = over (traverse . _2) sqrt (theoHvars tau0 xs)
 

--- a/src/TauSigma/Statistics/Total.hs
+++ b/src/TauSigma/Statistics/Total.hs
@@ -21,6 +21,7 @@ import Control.Lens (over, _2)
 
 import Data.Vector.Generic (Vector, (!))
 import qualified Data.Vector.Generic as V
+import qualified Data.Vector.Unboxed as U
 
 import TauSigma.Statistics.Types
 import TauSigma.Statistics.Util
@@ -38,9 +39,9 @@ xs !* i
 infixl 9 !*
 
 -- | TOTVAR estimator at one sampling interval.
-totvar :: (Vector v Double) =>
-          Tau0 Double -> Int -> v (Time Double) -> Sigma Double
+totvar :: (Vector v Double) => OneTau v
 {-# INLINABLE totvar #-}
+{-# SPECIALIZE totvar :: OneTau U.Vector #-}
 totvar tau0 m xs = sumsq 0 (V.length xs - 1) term / divisor
   where divisor = 2 * m'^2 * tau0^2 * (len - 2)
           where m' = fromIntegral m
@@ -49,24 +50,24 @@ totvar tau0 m xs = sumsq 0 (V.length xs - 1) term / divisor
           where i = notI+1
 
 -- | Overlapped estimator of Allan deviation at one sampling interval.
-totdev :: (Vector v Double) =>
-          Tau0 Double -> Int -> v (Time Double) -> Sigma Double
+totdev :: (Vector v Double) => OneTau v
 {-# INLINABLE totdev#-}
+{-# SPECIALIZE totdev :: OneTau U.Vector #-}
 totdev tau0 m xs = sqrt (totvar tau0 m xs)
 
 -- | Overlapped estimator of Allan variance at all sampling intervals.
-totvars :: (Vector v Double) =>
-           Tau0 Double -> v (Time Double) -> [TauSigma Double]
+totvars :: (Vector v Double) => AllTau v
 {-# INLINABLE totvars #-}
+{-# SPECIALIZE totvars :: AllTau U.Vector #-}
 totvars tau0 xs = map go taus
   where taus = [1 .. V.length xs - 2]
         go m = (fromIntegral m * tau0, totvar tau0 m xs)
 
                     
 -- | Overlapped estimator of Allan deviation at all sampling intervals.
-totdevs :: (Vector v Double) =>
-           Tau0 Double -> v (Time Double) -> [TauSigma Double]
+totdevs :: (Vector v Double) => AllTau v
 {-# INLINABLE totdevs #-}
+{-# SPECIALIZE totdevs :: AllTau U.Vector #-}
 totdevs tau0 xs = over (traverse . _2) sqrt (totvars tau0 xs)
 
 

--- a/src/TauSigma/Statistics/Total.hs
+++ b/src/TauSigma/Statistics/Total.hs
@@ -38,7 +38,8 @@ xs !* i
 infixl 9 !*
 
 -- | TOTVAR estimator at one sampling interval.
-totvar :: (Fractional a, Vector v a) => Tau0 a -> Int -> v a -> a
+totvar :: (Vector v Double) =>
+          Tau0 Double -> Int -> v (Time Double) -> Sigma Double
 {-# INLINABLE totvar #-}
 totvar tau0 m xs = sumsq 0 (V.length xs - 1) term / divisor
   where divisor = 2 * m'^2 * tau0^2 * (len - 2)
@@ -48,12 +49,14 @@ totvar tau0 m xs = sumsq 0 (V.length xs - 1) term / divisor
           where i = notI+1
 
 -- | Overlapped estimator of Allan deviation at one sampling interval.
-totdev :: (Floating a, Vector v a) => Tau0 a -> Int -> v a -> a
+totdev :: (Vector v Double) =>
+          Tau0 Double -> Int -> v (Time Double) -> Sigma Double
 {-# INLINABLE totdev#-}
 totdev tau0 m xs = sqrt (totvar tau0 m xs)
 
 -- | Overlapped estimator of Allan variance at all sampling intervals.
-totvars :: (RealFrac a, Vector v a) => Tau0 a -> v a -> [TauSigma a]
+totvars :: (Vector v Double) =>
+           Tau0 Double -> v (Time Double) -> [TauSigma Double]
 {-# INLINABLE totvars #-}
 totvars tau0 xs = map go taus
   where taus = [1 .. V.length xs - 2]
@@ -61,7 +64,8 @@ totvars tau0 xs = map go taus
 
                     
 -- | Overlapped estimator of Allan deviation at all sampling intervals.
-totdevs :: (RealFloat a, Vector v a) => Tau0 a -> v a -> [TauSigma a]
+totdevs :: (Vector v Double) =>
+           Tau0 Double -> v (Time Double) -> [TauSigma Double]
 {-# INLINABLE totdevs #-}
 totdevs tau0 xs = over (traverse . _2) sqrt (totvars tau0 xs)
 

--- a/src/TauSigma/Statistics/Types.hs
+++ b/src/TauSigma/Statistics/Types.hs
@@ -4,7 +4,12 @@ module TauSigma.Statistics.Types
        , Time
        , Sigma
        , TauSigma
+       , OneTau
+       , AllTau
        ) where
+
+import Data.Vector.Generic (Vector)
+
 
 -- | Type synonym for values that represent the smallest sampling
 -- interval in a data set.
@@ -24,3 +29,12 @@ type Sigma a = a
 
 -- | A pair of a 'Tau' and a 'Sigma'.
 type TauSigma a = (Tau a, Sigma a)
+
+
+-- | The common type that we use for most of the statistical functions
+-- | that produce a result at only one tau.
+type OneTau v = Tau0 Double -> Int -> v (Time Double) -> Sigma Double
+
+-- | The common type that we use for most of the statistical functions
+-- | that produce a result at all taus.
+type AllTau v = Tau0 Double -> v (Time Double) -> [TauSigma Double]

--- a/src/TauSigma/Statistics/Util.hs
+++ b/src/TauSigma/Statistics/Util.hs
@@ -10,6 +10,8 @@ module TauSigma.Statistics.Util
 import Data.Vector.Generic (Vector)
 import qualified Data.Vector.Generic as V
 
+import Numeric.Sum (KBNSum, kbn, add, zero)
+
 import Text.Printf
 
 
@@ -28,29 +30,30 @@ differences xs = V.zipWith (+) (V.map negate xs) (V.tail xs)
 
 -- | Sum a series of 'Int'-indexed terms.  Inclusive start, exclusive end.
 summation
-  :: Num a =>
-     String       -- ^ A name to be printed in errors (for troubleshooting).
-  -> Int          -- ^ Starting index (inclusive)
-  -> Int          -- ^ Ending index (exclusive)
-  -> (Int -> a)   -- ^ Term of summation
-  -> a
+  :: String           -- ^ A name to print in errors (for troubleshooting).
+  -> Int              -- ^ Starting index (inclusive)
+  -> Int              -- ^ Ending index (exclusive)
+  -> (Int -> Double)  -- ^ Term of summation
+  -> Double
 {-# INLINE summation #-}
 summation name from to term
   | from > to =
       error (printf "%s: bad range in summation: %d to %d" name from to)
-  | otherwise = go 0 from
-  where go subtotal i
-          | i < to    = go (subtotal + term i) (i+1)
+  | otherwise = kbn (go zero from)
+  where go :: KBNSum -> Int -> KBNSum
+        go subtotal i
+          | i < to    = go (subtotal `add` term i) (i+1)
           | otherwise = subtotal
 
 -- | Sum the squares of a series of 'Int'-indexed terms.  Inclusive
 -- start, exclusive end.
-sumsq :: Num a => Int -> Int -> (Int -> a) -> a
+sumsq :: Int -> Int -> (Int -> Double) -> Double
 {-# INLINE sumsq #-}
 sumsq from to term
   | from > to = error (printf "bad range in sumsq: %d to %d" from to)
-  | otherwise = go 0 from
-  where go subtotal i
-          | i < to    = go (subtotal + (term i)^2) (i+1)
+  | otherwise = kbn (go zero from)
+  where go :: KBNSum -> Int -> KBNSum
+        go subtotal i
+          | i < to    = go (subtotal `add` ((term i)^2)) (i+1)
           | otherwise = subtotal
 

--- a/tau-sigma.cabal
+++ b/tau-sigma.cabal
@@ -42,6 +42,7 @@ library
                      , filepath 
                      , lens 
                      , mtl 
+                     , math-functions
                      , mwc-random
                      , mwc-random-monad
                      , monad-primitive

--- a/tau-sigma.cabal
+++ b/tau-sigma.cabal
@@ -1,5 +1,5 @@
 name:                tau-sigma
-version:             0.4.4
+version:             0.5.0
 synopsis:            A command-line utility for frequency stability analysis.
 license:             BSD3
 license-file:        LICENSE

--- a/test/TauSigma/Statistics/HoweSpec.hs
+++ b/test/TauSigma/Statistics/HoweSpec.hs
@@ -29,7 +29,7 @@ spec = do
     describe "Theo1 DEV" $ do
       it "m = 10" $ do
         let (tau, sigma) = fromJust $ theo1dev 86400 10 howeData
-        sigma `shouldBeAbout` (7.66e-15, 1e-17)
+        sigma `shouldBeAbout` (7.66e-15, 7e-18)
 
 actual `shouldBeAbout` (expected, tolerance)  =
   unless (delta <= tolerance) (expectationFailure message)

--- a/test/TauSigma/Statistics/NBSSpec.hs
+++ b/test/TauSigma/Statistics/NBSSpec.hs
@@ -38,7 +38,7 @@ spec = do
       it "tau = 1" $ totdev 1 1 `shouldBeAbout` 91.22945
       it "tau = 2" $ totdev 1 2 `shouldBeAbout` 93.90379
 
-  where shouldBeAbout = comparison nbsData 5.0e-5
+  where shouldBeAbout = comparison nbsData 4.0e-6
 
 
 -- | NBS Monograph 140, Annex 8.E Test Data

--- a/test/TauSigma/Statistics/RileySpec.hs
+++ b/test/TauSigma/Statistics/RileySpec.hs
@@ -47,7 +47,7 @@ spec = do
       it "tau = 10"  $ totdev 1  10 `shouldBeAbout` 9.134743e-02
       it "tau = 100" $ totdev 1 100 `shouldBeAbout` 3.406530e-02
 
-  where shouldBeAbout = comparison rileyData 5.0e-7
+  where shouldBeAbout = comparison rileyData 2.5e-7
 
 
 -- | Riley's test data (http://www.wriley.com/tst_suit.dat).

--- a/test/TauSigma/Statistics/SlopeTest.hs
+++ b/test/TauSigma/Statistics/SlopeTest.hs
@@ -10,7 +10,7 @@ module TauSigma.Statistics.SlopeTest
        ) where
 
 import Data.Tagged
-import Data.Vector (Vector)
+import Data.Vector.Unboxed (Vector)
 
 import Pipes
 import qualified Pipes.Prelude as P


### PR DESCRIPTION
Use KBN summation instead of naïve floating summation; see [`Numeric.Sum`](https://hackage.haskell.org/package/math-functions-0.1.5.2/docs/Numeric-Sum.html).  This forces the statistical functions' types to `Double`, hence it is an incompatible change (and the version goes up to 0.5.0).

After fixing a performance regression (inline/specialization related), this version is 30-40% slower on the TheoH benchmarks.
